### PR TITLE
Update SDK Output Directory

### DIFF
--- a/libs/SDKLibrary/PalworldSDK.vcxproj
+++ b/libs/SDKLibrary/PalworldSDK.vcxproj
@@ -78,12 +78,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)\lib</OutDir>
+    <OutDir>$(ProjectDir)\lib</OutDir>
     <TargetName>$(ProjectName)d</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)\libs\SDKLibrary\lib</OutDir>
+    <OutDir>$(ProjectDir)\lib</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
SDK Lib directory has been properly updated to build within its project directory , as it should be.

The main solution searches `${SolutionDir}\libs\SDKLibrary\lib\<lib name>` when compiling